### PR TITLE
Add callback param to collect()

### DIFF
--- a/rgc/main.py
+++ b/rgc/main.py
@@ -24,11 +24,14 @@ def main():
     dryrun = params.get('dryrun', False)
     rule = params.get('rule', None)
     rule_param = params.get('ruleparam', None)
+    showprogress = params.get('progress', True)
 
     rule_instance = AVAILABLE_RULES[rule](rule_param)
 
     try:
-        deleted = collect(container=container, dryrun=dryrun, rule=rule_instance, user=user, key=key)
+        deleted = collect(container=container, dryrun=dryrun,
+                          rule=rule_instance, user=user, key=key,
+                          showprogress=showprogress)
         print deleted
         print "Removing {0} objects from container {1}".format(len(deleted), container)
     except AuthenticationFailed as auth:

--- a/rgc/rgc.py
+++ b/rgc/rgc.py
@@ -5,7 +5,7 @@ import cloudfiles
 from clint.textui import progress
 
 
-def collect(user, key, rule, container='', dryrun=False):
+def collect(user, key, rule, container='', dryrun=False, showprogress=False):
     """
     Connects to rackspace with the user and the key and crawls every container
     applying the rule to each cloudfile object. If the rule applies, i.e.
@@ -27,7 +27,9 @@ def collect(user, key, rule, container='', dryrun=False):
 
     deleted = []
     for cont in containers:
-        for obj in progress.bar(cont.get_objects(), label="Removing Objects"):
+        objs = progress.bar(cont.get_objects(),label="Collecting Objects",
+                            hide=not showprogress)
+        for obj in objs:
             if rule.apply(obj):
                 if not dryrun:
                     cont.delete_object(obj.name)

--- a/test/test_collect.py
+++ b/test/test_collect.py
@@ -111,6 +111,37 @@ class TestCollect(unittest.TestCase):
                     [mock.call(mock.ANY, label=mock.ANY, hide=False)],
                     progressbar.call_args_list)
 
+    def test_delete_is_caled_when_no_cb_is_passed(self):
+        mock_obj = mock.MagicMock()
+        mock_obj.name = 'mock'
+
+        mock_cont = mock.MagicMock()
+        mock_cont.name = 'container'
+        mock_cont.get_objects.return_value = [mock_obj]
+
+        mock_conn = mock.MagicMock()
+        mock_conn.get_all_containers.return_value = [mock_cont]
+        mock_conn.get_container.return_value = mock_cont
+        with mock.patch('cloudfiles.get_connection', return_value=mock_conn):
+            collect(rule=Rule(), container='container', user=mock.ANY, key=mock.ANY)
+            self.assertIn(mock.call.delete_object(mock_obj.name), mock_cont.method_calls)
+
+    def test_cb_is_called(self):
+        mock_obj = mock.MagicMock()
+        mock_obj.name = 'mock'
+
+        mock_cont = mock.MagicMock()
+        mock_cont.name = 'container'
+        mock_cont.get_objects.return_value = [mock_obj]
+
+        mock_conn = mock.MagicMock()
+        mock_conn.get_all_containers.return_value = [mock_cont]
+        mock_conn.get_container.return_value = mock_cont
+        with mock.patch('cloudfiles.get_connection', return_value=mock_conn):
+            cb = mock.MagicMock()
+            collect(rule=Rule(), container='container', user=mock.ANY, key=mock.ANY, cb=cb)
+            self.assertEqual(1, cb.call_count)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_collect.py
+++ b/test/test_collect.py
@@ -94,6 +94,23 @@ class TestCollect(unittest.TestCase):
         self.assertNotIn(mock.call.delete_object(mock_obj2.name), mock_cont2.method_calls)
         self.assertItemsEqual([mock_obj1.name], deleted)
 
+    def test_progress_bar_kwarg(self):
+        mock_conn = mock.MagicMock()
+        mock_conn.get_all_containers.return_value = [mock.MagicMock()]
+
+        with mock.patch('cloudfiles.get_connection', return_value=mock_conn):
+             with mock.patch('clint.textui.progress.bar') as progressbar:
+                 collect(rule=Rule(), user=mock.ANY, key=mock.ANY)
+                 self.assertEqual(
+                     [mock.call(mock.ANY, label=mock.ANY, hide=True)],
+                     progressbar.call_args_list)
+
+             with mock.patch('clint.textui.progress.bar') as progressbar:
+                 collect(rule=Rule(), user=mock.ANY, key=mock.ANY, showprogress=True)
+                 self.assertEqual(
+                    [mock.call(mock.ANY, label=mock.ANY, hide=False)],
+                    progressbar.call_args_list)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -87,7 +87,7 @@ class MainTest(unittest.TestCase):
             sys.argv = ['rgc', '--rule', 'isold', '--container', 'trash', '--dryrun']
             main()
 
-            self.assertEquals([mock.call(rule=rule_instance_mock, container='trash', dryrun=True, user=mock.ANY, key=mock.ANY)], mockcollect.call_args_list)
+            self.assertEquals([mock.call(rule=rule_instance_mock, container='trash', dryrun=True, user=mock.ANY, key=mock.ANY, showprogress=True)], mockcollect.call_args_list)
 
             del os.environ['user']
             del os.environ['key']

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -26,11 +26,13 @@ class MainTest(unittest.TestCase):
 
     def test_impossible_to_authenticate(self):
         os.environ['user'] = 'sieve'
-        self.assertTrue(_impossible_to_authenticate(), 'Nao deveria ser possivel autenticar apenas com user')
+        self.assertTrue(_impossible_to_authenticate(),
+                        'Nao deveria ser possivel autenticar apenas com user')
 
         os.environ['key'] = 'sieve'
         del os.environ['user']
-        self.assertTrue(_impossible_to_authenticate(), 'Nao deveria ser possivel autenticar apenas com key')
+        self.assertTrue(_impossible_to_authenticate(),
+                        'Nao deveria ser possivel autenticar apenas com key')
 
         os.environ['key'] = 'sieve'
         os.environ['user'] = 'sieve'
@@ -42,7 +44,7 @@ class MainTest(unittest.TestCase):
 
     def test_no_environ_vars(self):
         """
-        Deveos mostrar a mensagem de "help" caso falte alguma informação
+        Devemos mostrar a mensagem de "help" caso falte alguma informação
         para o rgc poder rodar
         """
         with mock.patch('sys.stderr'),\
@@ -56,7 +58,9 @@ class MainTest(unittest.TestCase):
             sys.argv = ['rgc']
             _validate_params({})
             self.assertTrue(sys.stderr.write.call_count > 1)
-            self.assertEquals(mock.call("Authentication tokens not present, please verify that you have os.environ['user'] and os.environ['key']"), sys.stderr.write.call_args_list[0])
+            self.assertEquals(
+               mock.call("Authentication tokens not present, please verify that you have os.environ['user'] and os.environ['key']"),
+               sys.stderr.write.call_args_list[0])
 
     def test_rule_validation(self):
         """
@@ -87,7 +91,11 @@ class MainTest(unittest.TestCase):
             sys.argv = ['rgc', '--rule', 'isold', '--container', 'trash', '--dryrun']
             main()
 
-            self.assertEquals([mock.call(rule=rule_instance_mock, container='trash', dryrun=True, user=mock.ANY, key=mock.ANY, showprogress=True)], mockcollect.call_args_list)
+            self.assertEquals(
+                [mock.call(rule=rule_instance_mock, container='trash',
+                           dryrun=True, user=mock.ANY, key=mock.ANY,
+                           showprogress=True)],
+                mockcollect.call_args_list)
 
             del os.environ['user']
             del os.environ['key']


### PR DESCRIPTION
This patch does 2 things:
1. make `collect` show progress on demand only (so not to break logs when rgc is used as lib);
2. make `collect` call a callback instead of simply deleting the objects; the default cb is to delete;
3. refactor some tests.
